### PR TITLE
Feat: adds the condition verification file

### DIFF
--- a/Luffie-contract/contracts/condition-verification.clar
+++ b/Luffie-contract/contracts/condition-verification.clar
@@ -49,3 +49,149 @@
 (define-data-var next-rental-id uint u1)
 (define-data-var next-item-id uint u1)
 
+;; Function to register a new item
+(define-public (register-item)
+  (let
+    ((item-id (var-get next-item-id)))
+    (map-insert items
+      { item-id: item-id }
+      { owner: tx-sender }
+    )
+    (var-set next-item-id (+ item-id u1))
+    (ok item-id)
+  )
+)
+
+;; Function to start a rental
+(define-public (start-rental (item-id uint))
+  (let
+    (
+      (rental-id (var-get next-rental-id))
+      (item (unwrap! (map-get? items { item-id: item-id }) err-not-found))
+    )
+    (asserts! (is-eq (get owner item) tx-sender) err-unauthorized)
+    (map-insert rentals
+      { rental-id: rental-id }
+      {
+        renter: tx-sender,
+        owner: tx-sender,
+        item-id: item-id,
+        start-time: block-height,
+        end-time: u0,
+        initial-condition: none,
+        final-condition: none,
+        status: "started"
+      }
+    )
+    (var-set next-rental-id (+ rental-id u1))
+    (ok rental-id)
+  )
+)
+
+;; Function to submit initial condition report
+(define-public (submit-initial-condition (rental-id uint) (condition-hash (buff 32)))
+  (let
+    ((rental (unwrap! (map-get? rentals { rental-id: rental-id }) err-not-found)))
+    (asserts! (is-eq (get status rental) "started") err-already-rented)
+    (asserts! (is-eq (get owner rental) tx-sender) err-unauthorized)
+    (map-set rentals
+      { rental-id: rental-id }
+      (merge rental {
+        initial-condition: (some condition-hash),
+        status: "in-progress"
+      })
+    )
+    (ok true)
+  )
+)
+
+;; Function to submit final condition report
+(define-public (submit-final-condition (rental-id uint) (condition-hash (buff 32)))
+  (let
+    ((rental (unwrap! (map-get? rentals { rental-id: rental-id }) err-not-found)))
+    (asserts! (is-eq (get status rental) "in-progress") err-not-rented)
+    (asserts! (is-eq (get renter rental) tx-sender) err-unauthorized)
+    (map-set rentals
+      { rental-id: rental-id }
+      (merge rental {
+        final-condition: (some condition-hash),
+        status: "completed",
+        end-time: block-height
+      })
+    )
+    (ok true)
+  )
+)
+
+;; Function to get rental details
+(define-read-only (get-rental-details (rental-id uint))
+  (map-get? rentals { rental-id: rental-id })
+)
+
+;; Function to initiate a dispute
+(define-public (initiate-dispute (rental-id uint))
+  (let
+    ((rental (unwrap! (map-get? rentals { rental-id: rental-id }) err-not-found)))
+    (asserts! (or (is-eq (get owner rental) tx-sender) (is-eq (get renter rental) tx-sender)) err-unauthorized)
+    (asserts! (is-eq (get status rental) "completed") err-not-rented)
+    (asserts! (is-none (map-get? disputes { rental-id: rental-id })) err-already-disputed)
+    (map-insert disputes
+      { rental-id: rental-id }
+      {
+        initiator: tx-sender,
+        owner-evidence: none,
+        renter-evidence: none,
+        resolution: none
+      }
+    )
+    (map-set rentals
+      { rental-id: rental-id }
+      (merge rental { status: "disputed" })
+    )
+    (ok true)
+  )
+)
+
+;; Function to submit evidence for a dispute
+(define-public (submit-dispute-evidence (rental-id uint) (evidence-hash (buff 32)))
+  (let
+    ((rental (unwrap! (map-get? rentals { rental-id: rental-id }) err-not-found))
+     (dispute (unwrap! (map-get? disputes { rental-id: rental-id }) err-not-disputed)))
+    (asserts! (or (is-eq (get owner rental) tx-sender) (is-eq (get renter rental) tx-sender)) err-unauthorized)
+    (if (is-eq (get owner rental) tx-sender)
+      (map-set disputes
+        { rental-id: rental-id }
+        (merge dispute { owner-evidence: (some evidence-hash) })
+      )
+      (map-set disputes
+        { rental-id: rental-id }
+        (merge dispute { renter-evidence: (some evidence-hash) })
+      )
+    )
+    (ok true)
+  )
+)
+
+;; Function to resolve a dispute (only contract owner can do this)
+(define-public (resolve-dispute (rental-id uint) (resolution (string-ascii 20)))
+  (let
+    ((rental (unwrap! (map-get? rentals { rental-id: rental-id }) err-not-found))
+     (dispute (unwrap! (map-get? disputes { rental-id: rental-id }) err-not-disputed)))
+    (asserts! (is-eq tx-sender contract-owner) err-unauthorized)
+    (map-set disputes
+      { rental-id: rental-id }
+      (merge dispute { resolution: (some resolution) })
+    )
+    (map-set rentals
+      { rental-id: rental-id }
+      (merge rental { status: "resolved" })
+    )
+    (ok true)
+  )
+)
+
+;; Function to get dispute details
+(define-read-only (get-dispute-details (rental-id uint))
+  (map-get? disputes { rental-id: rental-id })
+)
+


### PR DESCRIPTION
# Condition Verification Smart Contract for Rentals

## Overview
The Condition Verification Smart Contract is designed for rental scenarios where items are rented between owners and renters. The contract manages the rental lifecycle, including item registration, rental initiation, condition reporting, and dispute resolution. Both the owner and renter can submit evidence regarding the condition of the rented item, and the contract ensures transparency, security, and accountability throughout the process.

## Features

### 1. **Register Item**
Owners can register items they wish to rent out, which are identified by a unique `item-id`.

- **Function**: `register-item`
- **Returns**: A unique `item-id` for the newly registered item.

### 2. **Start Rental**
Rental agreements can be initiated for items. This records the rental details, including the renter, owner, rental start time, and status. The initial condition of the item is not yet recorded at this stage.

- **Function**: `start-rental(item-id)`
- **Arguments**:
  - `item-id` (uint) - The ID of the item being rented.
- **Returns**: A unique `rental-id` for the newly started rental.

### 3. **Submit Initial Condition Report**
Before the rental item is used, the owner submits the initial condition of the item by providing a hash of the condition report.

- **Function**: `submit-initial-condition(rental-id, condition-hash)`
- **Arguments**:
  - `rental-id` (uint) - The ID of the rental.
  - `condition-hash` (buff 32) - A hash representing the initial condition of the item.
- **Returns**: `true` if the initial condition was successfully submitted and the rental status changes to "in-progress."

### 4. **Submit Final Condition Report**
At the end of the rental, the renter submits the final condition report for the item. The report is validated, and the rental status is marked as "completed."

- **Function**: `submit-final-condition(rental-id, condition-hash)`
- **Arguments**:
  - `rental-id` (uint) - The ID of the rental.
  - `condition-hash` (buff 32) - A hash representing the final condition of the item.
- **Returns**: `true` if the final condition was successfully submitted and the rental status is marked as "completed."

### 5. **Initiate Dispute**
Either the owner or the renter can initiate a dispute if they believe the item was not returned in the agreed-upon condition. Disputes can only be initiated once the rental is completed.

- **Function**: `initiate-dispute(rental-id)`
- **Arguments**:
  - `rental-id` (uint) - The ID of the rental to dispute.
- **Returns**: `true` if the dispute was successfully initiated, and the rental status is changed to "disputed."

### 6. **Submit Evidence for Dispute**
Both the owner and renter can submit evidence for the dispute. The evidence is stored as hashes, which can be reviewed during the dispute resolution process.

- **Function**: `submit-dispute-evidence(rental-id, evidence-hash)`
- **Arguments**:
  - `rental-id` (uint) - The ID of the disputed rental.
  - `evidence-hash` (buff 32) - A hash representing the evidence.
- **Returns**: `true` if the evidence was successfully submitted.

### 7. **Resolve Dispute**
The contract owner (administrator) can resolve disputes by providing a resolution. The rental status is updated to "resolved" once the dispute is resolved.

- **Function**: `resolve-dispute(rental-id, resolution)`
- **Arguments**:
  - `rental-id` (uint) - The ID of the disputed rental.
  - `resolution` (string-ascii 20) - The resolution of the dispute (e.g., "owner win," "renter win").
- **Returns**: `true` if the dispute was successfully resolved and the rental status is updated to "resolved."

### 8. **Get Rental Details**
Users can query rental details, including the status, owner, renter, item ID, initial and final condition reports, and rental times.

- **Function**: `get-rental-details(rental-id)`
- **Arguments**:
  - `rental-id` (uint) - The ID of the rental.
- **Returns**: Rental details including the renter, owner, item ID, status, condition reports, and rental times.

### 9. **Get Dispute Details**
Users can query the details of a dispute, including evidence submitted by both parties and the resolution if available.

- **Function**: `get-dispute-details(rental-id)`
- **Arguments**:
  - `rental-id` (uint) - The ID of the disputed rental.
- **Returns**: The details of the dispute, including the evidence from both parties and the resolution status.

## Data Structures

### `rentals`
A mapping that stores details for each rental:
- `rental-id`: Unique identifier for the rental.
- `renter`: The principal (user) who rented the item.
- `owner`: The principal (user) who owns the item.
- `item-id`: The ID of the rented item.
- `start-time`: The block height when the rental started.
- `end-time`: The block height when the rental ended.
- `initial-condition`: A hash of the initial condition report (optional).
- `final-condition`: A hash of the final condition report (optional).
- `status`: The current status of the rental (e.g., "started," "in-progress," "completed," "disputed," "resolved").

### `items`
A mapping that stores details about each item:
- `item-id`: Unique identifier for the item.
- `owner`: The principal who owns the item.

### `disputes`
A mapping that stores details about disputes:
- `rental-id`: The ID of the rental in dispute.
- `initiator`: The principal (user) who initiated the dispute.
- `owner-evidence`: Evidence submitted by the owner (optional).
- `renter-evidence`: Evidence submitted by the renter (optional).
- `resolution`: The resolution of the dispute (optional).

## Error Handling

- **err-unauthorized (u403)**: The sender is not authorized to perform the action.
- **err-already-rented (u404)**: The item has already been rented.
- **err-not-rented (u405)**: The item has not been rented yet.
- **err-not-found (u404)**: The rental or item does not exist.
- **err-already-disputed (u406)**: A dispute has already been initiated for this rental.
- **err-not-disputed (u407)**: The rental is not in dispute.

## Usage Examples

### 1. **Registering an Item**
To register a new item for rental:
```clojure
(register-item)
```
Returns a unique `item-id` for the registered item.

### 2. **Starting a Rental**
To start a rental for an item:
```clojure
(start-rental item-id)
```
Returns a unique `rental-id` for the new rental.

### 3. **Submitting Initial Condition Report**
To submit the initial condition report for a rental:
```clojure
(submit-initial-condition rental-id condition-hash)
```
The rental status will change to "in-progress."

### 4. **Submitting Final Condition Report**
To submit the final condition report after the rental ends:
```clojure
(submit-final-condition rental-id condition-hash)
```
The rental status will change to "completed."

### 5. **Initiating a Dispute**
To initiate a dispute over a rental:
```clojure
(initiate-dispute rental-id)
```
The rental status will change to "disputed."

### 6. **Resolving a Dispute**
To resolve a dispute:
```clojure
(resolve-dispute rental-id resolution)
```
The rental status will change to "resolved."

### 7. **Querying Rental Details**
To get rental details:
```clojure
(get-rental-details rental-id)
```
Returns details of the rental, including status and condition reports.

### 8. **Querying Dispute Details**
To get dispute details:
```clojure
(get-dispute-details rental-id)
```
Returns the details of the dispute.

## Conclusion
The Condition Verification Smart Contract facilitates transparent and secure rental agreements, allowing owners and renters to manage and verify the condition of items before and after rentals. The dispute resolution process ensures that any disagreements between parties can be fairly addressed, with evidence collected and a resolution provided by the contract owner.